### PR TITLE
Fix typo that prevents urls from being auto linked

### DIFF
--- a/src/Providers/ParsedownServiceProvider.php
+++ b/src/Providers/ParsedownServiceProvider.php
@@ -59,7 +59,7 @@ class ParsedownServiceProvider extends ServiceProvider
             );
 
             $parsedown->setUrlsLinked(
-                Config::get('parswdown.urls_linked')
+                Config::get('parsedown.urls_linked')
             );
 
             return $parsedown;


### PR DESCRIPTION
Just a small typo that I found.

Cheers!