### PR TITLE
Add missing quotes for the vendor:publish command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This package uses the `Parsedown\Providers\ParsedownServiceProvider` service pro
 You can overwrite these values by publishing the `config/parsedown.php` file with the following command:
 
 ``` sh
-php artisan vendor:publish --provider=Parsedown\Providers\ParsedownServiceProvider
+php artisan vendor:publish --provider="Parsedown\Providers\ParsedownServiceProvider"
 ```
 
 ### Usage


### PR DESCRIPTION
On macOS the vendor:publish command only works when the provider is enclosed in quotation marks:

```
php artisan vendor:publish --provider="Parsedown\Providers\ParsedownServiceProvider"
```